### PR TITLE
Add target parameter supplier

### DIFF
--- a/src/main/kotlin/DataClassMapper.kt
+++ b/src/main/kotlin/DataClassMapper.kt
@@ -2,10 +2,12 @@ package com.github.jangalinski.kotlin
 
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 
 typealias Mapper<I, O> = (I) -> O
+typealias targetParameterSupplier<O> = () -> O
 
 /**
  * Mapper that can convert one data class into another data class.
@@ -24,13 +26,14 @@ class DataClassMapper<I : Any, O : Any>(private val inType: KClass<I>, private v
   }
 
   val fieldMappers = mutableMapOf<String, Mapper<Any, Any>>()
+  private val targetParameterProviders = mutableMapOf<String, targetParameterSupplier<Any>>()
 
   private val outConstructor = outType.primaryConstructor!!
   private val inPropertiesByName by lazy { inType.memberProperties.associateBy { it.name } }
 
   private fun argFor(parameter: KParameter, data: I): Any? {
-    // get value from input data ...
-    val value = inPropertiesByName[parameter.name]?.get(data) ?: return null
+    // get value from input data or apply a default value to the target class
+    val value = inPropertiesByName[parameter.name]?.get(data) ?: return targetParameterProviders[parameter.name]?.invoke()
 
     // if a special mapper is registered, use it, otherwise keep value
     return fieldMappers[parameter.name]?.invoke(value) ?: value
@@ -39,6 +42,24 @@ class DataClassMapper<I : Any, O : Any>(private val inType: KClass<I>, private v
   inline fun <reified S : Any, reified T : Any> register(parameterName: String, crossinline mapper: Mapper<S, T>): DataClassMapper<I, O> = apply {
     this.fieldMappers[parameterName] = object : Mapper<Any, Any> {
       override fun invoke(data: Any): Any = mapper.invoke(data as S)
+    }
+  }
+
+  inline fun <reified C : Any, reified S : Any, reified T : Any> register(property: KProperty1<C, S>, crossinline mapper: Mapper<S, T>): DataClassMapper<I, O> = apply {
+    this.fieldMappers[property.name] = object : Mapper<Any, Any> {
+      override fun invoke(data: Any): Any = mapper.invoke(data as S)
+    }
+  }
+
+  fun <T : Any> targetParameterSupplier(parameterName: String, mapper: targetParameterSupplier<T>): DataClassMapper<I, O> = apply {
+    this.targetParameterProviders[parameterName] = object : targetParameterSupplier<Any> {
+      override fun invoke(): Any = mapper.invoke()
+    }
+  }
+
+  fun <S : Any, T : Any> targetParameterSupplier(property: KProperty1<S, Any?>, mapper: targetParameterSupplier<T>): DataClassMapper<I, O> = apply {
+    this.targetParameterProviders[property.name] = object : targetParameterSupplier<Any> {
+      override fun invoke(): Any = mapper.invoke()
     }
   }
 

--- a/src/test/kotlin/DataClassMapperTest.kt
+++ b/src/test/kotlin/DataClassMapperTest.kt
@@ -11,15 +11,27 @@ internal class DataClassMapperTest {
   data class BazIn(val foo: FooIn)
 
   data class FooOut(val name: String)
+  data class FooOut2(val name: String, val age: Int, val active: Boolean)
   data class BarOut(val name: String, val foos: Set<FooOut>)
   data class BazOut(val foo: FooOut)
 
 
   val fooMapper = DataClassMapper<FooIn, FooOut>()
+  var fooWithTargetParamsMapper = DataClassMapper<FooIn, FooOut2>()
+    .targetParameterSupplier("active") { true }
+    .targetParameterSupplier(FooOut2::age) { 65 }
+
   val bazMapper = DataClassMapper<BazIn, BazOut>()
     .register("foo", fooMapper)
-  val barMapper = DataClassMapper<BarIn,BarOut>()
+
+  val bazMapperAlternative = DataClassMapper<BazIn, BazOut>()
+    .register(BazIn::foo, fooMapper)
+
+  val barMapper = DataClassMapper<BarIn, BarOut>()
     .register("foos", setMapper(fooMapper))
+
+  val barMapperAlternative = DataClassMapper<BarIn, BarOut>()
+    .register(BarIn::foos, setMapper(fooMapper))
 
   @Test
   fun `simple mapping foo`() {
@@ -28,8 +40,15 @@ internal class DataClassMapperTest {
   }
 
   @Test
+  fun `simple mapping foo with default param in target`() {
+    assertThat(fooWithTargetParamsMapper(FooIn("kermit")))
+      .isEqualTo(FooOut2("kermit", 65, true))
+  }
+
+  @Test
   fun `transitive mapping baz(foo)`() {
     assertThat(bazMapper(BazIn(FooIn("piggy"))))
+      .isEqualTo(bazMapperAlternative(BazIn(FooIn("piggy"))))
       .isEqualTo(BazOut(FooOut("piggy")))
   }
 
@@ -38,7 +57,10 @@ internal class DataClassMapperTest {
     val inValue = BarIn("kermit", setOf(FooIn("piggy")))
 
     val outValue = barMapper(inValue)
+    val outValue2 = barMapperAlternative(inValue)
 
-    assertThat(outValue).isEqualTo(BarOut("kermit", setOf(FooOut("piggy"))))
+    assertThat(outValue)
+      .isEqualTo(outValue2)
+      .isEqualTo(BarOut("kermit", setOf(FooOut("piggy"))))
   }
 }


### PR DESCRIPTION
- targetParameterSupplier() allows setting a default value for a target constructor param which is not present in the source dataclass
Example:
`  var fooWithTargetParamsMapper = DataClassMapper<FooIn, FooOut2>()
    .targetParameterSupplier("active") { true }
    .targetParameterSupplier(FooOut2::age) { 65 }`

- There is an alternative way of declaring params in register() and targetParameterSupplier(): using the property reference instead of a String
Example:
`  val bazMapperAlternative = DataClassMapper<BazIn, BazOut>()
    .register(BazIn::foo, fooMapper)`
