### PR TITLE
Add enum class mapping feature

### DIFF
--- a/src/main/kotlin/DataClassMapper.kt
+++ b/src/main/kotlin/DataClassMapper.kt
@@ -64,7 +64,10 @@ class DataClassMapper<I : Any, O : Any>(private val inType: KClass<I>, private v
   }
 
   override fun invoke(data: I): O = with(outConstructor) {
-    callBy(parameters.associateWith { argFor(it, data) })
+    if (data is Enum<*>)
+      outType.java.enumConstants[data.ordinal]
+    else
+      callBy(parameters.associateWith { argFor(it, data) })
   }
 
   override fun toString(): String = "DataClassMapper($inType -> $outType)"


### PR DESCRIPTION
Added a feature for enum class mapping because when I was using this mapper I needed mapping for enum classes too because my data class was using some enum classes, so instead of using targetParameterSupplier() to pass the correct value from enum class that is used on the result side of mpping by comparing it to the original value of the enum class that is on the data providing side of the mapping, I edited the code so that we can simply map enum values to just by making a mapper for enum class and using register() to add that mapper to the original data class. Just a little contribution from my side, I hope you find it useful:).